### PR TITLE
The path to main program in 'go run' commands in the readme fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ resources:
 
 And run:
 
-```
-go run ./ init
-go run ./ generate score.yaml
+```sh
+go run ./cmd/score-xyz init
+go run ./cmd/score-xyz generate score.yaml
 ```
 
 The output `manifests.yaml` contains the following which indicates:


### PR DESCRIPTION
To start the program, the path to the file with the main function is required, otherwise the message `no Go files in /path/to/the/repos/score-xyz` will appear.