### PR TITLE
Fix and improve `--version` and add new `version` command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.26-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS builder
 
 ARG VERSION
+ARG GIT_COMMIT
+ARG BUILD_DATE
 
 # Set the current working directory inside the container.
 WORKDIR /go/src/github.com/score-spec/score-implementation-sample
@@ -11,7 +13,12 @@ RUN go mod download
 
 # Copy the entire project and build it.
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X github.com/score-spec/score-implementation-sample/internal/version.Version=${VERSION}" -o /usr/local/bin/score-implementation-sample ./cmd/score-implementation-sample
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build -ldflags="-s -w \
+        -X github.com/score-spec/score-implementation-sample/internal/version.Version=${VERSION} \
+        -X github.com/score-spec/score-implementation-sample/internal/version.GitCommit=${GIT_COMMIT} \
+        -X github.com/score-spec/score-implementation-sample/internal/version.BuildDate=${BUILD_DATE}" \
+    -o /usr/local/bin/score-implementation-sample ./cmd/score-implementation-sample
 
 # We can use gcr.io/distroless/static since we don't rely on any linux libs or state, but we need ca-certificates to connect to https/oci with the init command.
 FROM gcr.io/distroless/static:530158861eebdbbf149f7e7e67bfe45eb433a35c@sha256:5c7e2b465ac6a2a4e5f4f7f722ce43b147dabe87cb21ac6c4007ae5178a1fa58

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -44,7 +44,7 @@ const (
 
 var generateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "Run the conversion from score file to output manifests",
+	Short: "Run the conversion from Score file to output manifests",
 	Args:  cobra.ArbitraryArgs,
 	CompletionOptions: cobra.CompletionOptions{
 		HiddenDefaultCmd: true,
@@ -62,16 +62,16 @@ var generateCmd = &cobra.Command{
 		currentState := &sd.State
 
 		if len(args) != 1 && (cmd.Flags().Lookup(generateCmdOverridesFileFlag).Changed || cmd.Flags().Lookup(generateCmdOverridePropertyFlag).Changed || cmd.Flags().Lookup(generateCmdImageFlag).Changed) {
-			return fmt.Errorf("cannot use --%s, --%s, or --%s when 0 or more than 1 score files are provided", generateCmdOverridePropertyFlag, generateCmdOverridesFileFlag, generateCmdImageFlag)
+			return fmt.Errorf("cannot use --%s, --%s, or --%s when 0 or more than 1 Score files are provided", generateCmdOverridePropertyFlag, generateCmdOverridesFileFlag, generateCmdImageFlag)
 		}
 
 		slices.Sort(args)
 		for _, arg := range args {
 			var rawWorkload map[string]interface{}
 			if raw, err := os.ReadFile(arg); err != nil {
-				return fmt.Errorf("failed to read input score file: %s: %w", arg, err)
+				return fmt.Errorf("failed to read input Score file: %s: %w", arg, err)
 			} else if err = yaml.Unmarshal(raw, &rawWorkload); err != nil {
-				return fmt.Errorf("failed to decode input score file: %s: %w", arg, err)
+				return fmt.Errorf("failed to decode input Score file: %s: %w", arg, err)
 			}
 
 			// apply overrides
@@ -102,9 +102,9 @@ var generateCmd = &cobra.Command{
 
 			var workload scoretypes.Workload
 			if err = scoreschema.Validate(rawWorkload); err != nil {
-				return fmt.Errorf("invalid score file: %s: %w", arg, err)
+				return fmt.Errorf("invalid Score file: %s: %w", arg, err)
 			} else if err = scoreloader.MapSpec(&workload, rawWorkload); err != nil {
-				return fmt.Errorf("failed to decode input score file: %s: %w", arg, err)
+				return fmt.Errorf("failed to decode input Score file: %s: %w", arg, err)
 			}
 
 			// Apply image override
@@ -121,13 +121,13 @@ var generateCmd = &cobra.Command{
 			}
 
 			if currentState, err = currentState.WithWorkload(&workload, &arg, state.WorkloadExtras{}); err != nil {
-				return fmt.Errorf("failed to add score file to project: %s: %w", arg, err)
+				return fmt.Errorf("failed to add Score file to project: %s: %w", arg, err)
 			}
-			slog.Info("Added score file to project", "file", arg)
+			slog.Info("Added Score file to project", "file", arg)
 		}
 
 		if len(currentState.Workloads) == 0 {
-			return fmt.Errorf("project is empty, please add a score file")
+			return fmt.Errorf("project is empty, please add a Score file")
 		}
 
 		if currentState, err = currentState.WithPrimedResources(); err != nil {

--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -53,7 +53,7 @@ func TestGenerateWithoutScoreFiles(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", stdout)
 	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate"})
-	assert.EqualError(t, err, "project is empty, please add a score file")
+	assert.EqualError(t, err, "project is empty, please add a Score file")
 	assert.Equal(t, "", stdout)
 }
 
@@ -66,7 +66,7 @@ func TestInitAndGenerateWithBadFile(t *testing.T) {
 	assert.NoError(t, os.WriteFile(filepath.Join(td, "thing"), []byte(`"blah"`), 0644))
 
 	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "thing"})
-	assert.EqualError(t, err, "failed to decode input score file: thing: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `blah` into map[string]interface {}")
+	assert.EqualError(t, err, "failed to decode input Score file: thing: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `blah` into map[string]interface {}")
 	assert.Equal(t, "", stdout)
 }
 
@@ -79,7 +79,7 @@ func TestInitAndGenerateWithBadScore(t *testing.T) {
 	assert.NoError(t, os.WriteFile(filepath.Join(td, "thing"), []byte(`{}`), 0644))
 
 	stdout, _, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "thing"})
-	assert.EqualError(t, err, "invalid score file: thing: jsonschema: '' does not validate with https://score.dev/schemas/score#/required: missing properties: 'apiVersion', 'metadata', 'containers'")
+	assert.EqualError(t, err, "invalid Score file: thing: jsonschema: '' does not validate with https://score.dev/schemas/score#/required: missing properties: 'apiVersion', 'metadata', 'containers'")
 	assert.Equal(t, "", stdout)
 }
 

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -35,7 +35,7 @@ const (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialise the local state directory and sample score file",
+	Short: "Initialize the local state directory and sample Score file",
 	Args:  cobra.NoArgs,
 	CompletionOptions: cobra.CompletionOptions{
 		HiddenDefaultCmd: true,
@@ -104,7 +104,7 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	initCmd.Flags().StringP(initCmdFileFlag, "f", "score.yaml", "The score file to initialize")
-	initCmd.Flags().Bool(initCmdFileNoSampleFlag, false, "Disable generation of the sample score file")
+	initCmd.Flags().StringP(initCmdFileFlag, "f", "score.yaml", "The Score file to initialize")
+	initCmd.Flags().Bool(initCmdFileNoSampleFlag, false, "Disable generation of the sample Score file")
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -20,8 +20,10 @@ import (
 	"github.com/score-spec/score-implementation-sample/internal/version"
 )
 
+var ScoreImplementationName = "score-implementation-sample"
+
 var rootCmd = &cobra.Command{
-	Use:           "score-implementation-sample",
+	Use:           ScoreImplementationName,
 	SilenceErrors: true,
 	CompletionOptions: cobra.CompletionOptions{
 		HiddenDefaultCmd: true,

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	versionCmdFileNoLogo        = "no-logo"
+	versionCmdFileNoLogo         = "no-logo"
 	versionCmdFileNoUpdatesCheck = "no-updates-check"
-	logo                        = `
+	logo                         = `
                    ...    .............           
                .......   .............            
            .........     ............             
@@ -49,7 +49,7 @@ const (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Show the version for score-implementation-sample and new version to update if available.",
+	Short: "Show the version for " + ScoreImplementationName + " and new version to update if available.",
 	Args:  cobra.NoArgs,
 	CompletionOptions: cobra.CompletionOptions{
 		HiddenDefaultCmd: true,
@@ -62,11 +62,11 @@ var versionCmd = &cobra.Command{
 			fmt.Println(logo)
 		}
 
-		fmt.Println("score-implementation-sample", version.BuildVersionString())
+		fmt.Println(ScoreImplementationName, version.BuildVersionString())
 
 		if noUpdateCheck, _ := cmd.Flags().GetBool(versionCmdFileNoUpdatesCheck); !noUpdateCheck {
 			if newer, err := checkForNewerVersion(version.Version); err == nil && newer != "" {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nA newer version is available: %s\nUpdate at: https://github.com/score-spec/score-implementation-sample/releases/tag/%s\n", newer, newer)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nA newer version is available: %s\nUpdate at: https://github.com/score-spec/%s/releases/tag/%s\n", newer, ScoreImplementationName, newer)
 			}
 		}
 
@@ -79,7 +79,7 @@ var versionCmd = &cobra.Command{
 // or if the current version cannot be parsed.
 func checkForNewerVersion(currentVersion string) (string, error) {
 	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get("https://api.github.com/repos/score-spec/score-implementation-sample/releases/latest")
+	resp, err := client.Get("https://api.github.com/repos/score-spec/" + ScoreImplementationName + "/releases/latest")
 	if err != nil {
 		return "", err
 	}

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -28,22 +28,22 @@ import (
 
 const (
 	versionCmdFileNoLogo        = "no-logo"
-	versionCmdFileNoUpdateCheck = "no-update-check"
+	versionCmdFileNoUpdatesCheck = "no-updates-check"
 	logo                        = `
-                   ...    ..-----------           
-               .......   .....--------            
-           .........     ......------             
+                   ...    .............           
+               .......   .............            
+           .........     ............             
        .........        .....                     
       .......           ....   ..                 
-       ..........      .....   .....-             
-           ........   ......   .......---         
-              .....   .....       ......----      
-                      ....          .....---      
+       ..........      .....   ......             
+           ........   ......   ..........         
+              .....   .....       ..........      
+                      ....          ........      
               ...........       .........         
-           ..............    ........-            
+           ..............    .........            
          ................   ......                
          ...............    ..                    
-          -...........
+          ............
 	`
 )
 
@@ -58,12 +58,13 @@ var versionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 
-		if v, _ := cmd.Flags().GetBool(versionCmdFileNoLogo); !v {
+		if noLogo, _ := cmd.Flags().GetBool(versionCmdFileNoLogo); !noLogo {
 			fmt.Println(logo)
 		}
+
 		fmt.Println("score-implementation-sample", version.BuildVersionString())
 
-		if noUpdateCheck, _ := cmd.Flags().GetBool(versionCmdFileNoUpdateCheck); !noUpdateCheck {
+		if noUpdateCheck, _ := cmd.Flags().GetBool(versionCmdFileNoUpdatesCheck); !noUpdateCheck {
 			if newer, err := checkForNewerVersion(version.Version); err == nil && newer != "" {
 				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nA newer version is available: %s\nUpdate at: https://github.com/score-spec/score-implementation-sample/releases/tag/%s\n", newer, newer)
 			}
@@ -133,6 +134,6 @@ func parseSemver(v string) [3]int {
 
 func init() {
 	versionCmd.Flags().Bool(versionCmdFileNoLogo, false, "Do not show the Score logo")
-	versionCmd.Flags().Bool(versionCmdFileNoUpdateCheck, false, "Do not check for a new version")
+	versionCmd.Flags().Bool(versionCmdFileNoUpdatesCheck, false, "Do not check for a new version")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -15,15 +15,21 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/score-spec/score-implementation-sample/internal/version"
+	"github.com/spf13/cobra"
 )
 
 const (
-	versionCmdFileNoLogo = "no-logo"
+	versionCmdFileNoLogo        = "no-logo"
 	versionCmdFileNoUpdateCheck = "no-update-check"
-	logo =`
+	logo                        = `
                    ...    ..-----------           
                .......   .....--------            
            .........     ......------             
@@ -57,11 +63,76 @@ var versionCmd = &cobra.Command{
 		}
 		fmt.Println("score-implementation-sample", version.BuildVersionString())
 
+		if noUpdateCheck, _ := cmd.Flags().GetBool(versionCmdFileNoUpdateCheck); !noUpdateCheck {
+			if newer, err := checkForNewerVersion(version.Version); err == nil && newer != "" {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nA newer version is available: %s\nUpdate at: https://github.com/score-spec/score-implementation-sample/releases/tag/%s\n", newer, newer)
+			}
+		}
+
 		return nil
 	},
 }
 
+// checkForNewerVersion queries the GitHub releases API and returns the tag name of the latest
+// release if it is newer than currentVersion. Returns an empty string if no newer version is found
+// or if the current version cannot be parsed.
+func checkForNewerVersion(currentVersion string) (string, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get("https://api.github.com/repos/score-spec/score-implementation-sample/releases/latest")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status from releases API: %s", resp.Status)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+
+	if isNewerVersion(currentVersion, release.TagName) {
+		return release.TagName, nil
+	}
+	return "", nil
+}
+
+// isNewerVersion reports whether latestVersion is strictly greater than currentVersion.
+// Both versions may optionally start with a "v" prefix and are expected to follow semver
+// (MAJOR.MINOR.PATCH). Non-numeric or unparseable segments are treated as 0.
+func isNewerVersion(currentVersion, latestVersion string) bool {
+	current := parseSemver(currentVersion)
+	latest := parseSemver(latestVersion)
+	for i := range current {
+		if latest[i] > current[i] {
+			return true
+		}
+		if latest[i] < current[i] {
+			return false
+		}
+	}
+	return false
+}
+
+// parseSemver splits a version string (with an optional leading "v") into its three numeric
+// components [major, minor, patch]. Components that cannot be parsed are treated as 0.
+func parseSemver(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	var out [3]int
+	for i := 0; i < 3 && i < len(parts); i++ {
+		n, _ := strconv.Atoi(parts[i])
+		out[i] = n
+	}
+	return out
+}
+
 func init() {
 	versionCmd.Flags().Bool(versionCmdFileNoLogo, false, "Do not show the Score logo")
+	versionCmd.Flags().Bool(versionCmdFileNoUpdateCheck, false, "Do not check for a new version")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Score Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/score-spec/score-implementation-sample/internal/version"
+)
+
+const (
+	versionCmdFileNoLogo = "no-logo"
+	versionCmdFileNoUpdateCheck = "no-update-check"
+	logo =`
+                   ...    ..-----------           
+               .......   .....--------            
+           .........     ......------             
+       .........        .....                     
+      .......           ....   ..                 
+       ..........      .....   .....-             
+           ........   ......   .......---         
+              .....   .....       ......----      
+                      ....          .....---      
+              ...........       .........         
+           ..............    ........-            
+         ................   ......                
+         ...............    ..                    
+          -...........
+	`
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the version for score-implementation-sample and new version to update if available.",
+	Args:  cobra.NoArgs,
+	CompletionOptions: cobra.CompletionOptions{
+		HiddenDefaultCmd: true,
+	},
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		if v, _ := cmd.Flags().GetBool(versionCmdFileNoLogo); !v {
+			fmt.Println(logo)
+		}
+		fmt.Println("score-implementation-sample", version.BuildVersionString())
+
+		return nil
+	},
+}
+
+func init() {
+	versionCmd.Flags().Bool(versionCmdFileNoLogo, false, "Do not show the Score logo")
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,30 +16,14 @@ package version
 
 import (
 	"fmt"
-	"runtime/debug"
+	"runtime"
 )
 
 var Version = "unknown"
+var GitCommit = "unknown"
+var BuildDate = "unknown"
 
 // BuildVersionString constructs a version string by looking at the build metadata injected at build time.
 func BuildVersionString() string {
-	versionNumber, buildTime, gitSha, isDirtySuffix := Version, "local", "unknown", ""
-	if info, ok := debug.ReadBuildInfo(); ok {
-		if Version == "unknown" || Version == "" {
-			versionNumber = info.Main.Version
-		}
-		for _, setting := range info.Settings {
-			switch setting.Key {
-			case "vcs.time":
-				buildTime = setting.Value
-			case "vcs.revision":
-				gitSha = setting.Value
-			case "vcs.modified":
-				if setting.Value == "true" {
-					isDirtySuffix = "+dirty"
-				}
-			}
-		}
-	}
-	return fmt.Sprintf("%s (build: %s, sha: %s%s)", versionNumber, buildTime, gitSha, isDirtySuffix)
+	return fmt.Sprintf("%s (%s - %s/%s)\ngit commit: %s\nbuild date: %s", Version, runtime.Version(), runtime.GOOS, runtime.GOARCH, GitCommit, BuildDate)
 }


### PR DESCRIPTION
Fix and improve `--version` and add new `version` command.

Update for `score-implementation-sample --version`:
- Before
```none
score-implementation-sample 0.30.0 (build: 2026-01-01T18:28:02Z, sha: 2b994a35d0593c66f908135d5c321b0fd4d5c553-dirty)
```
- Before with the container image (`docker run --rm -it scorespec/score-implementation-sample:latest --version`):
```none
score-implementation-sample 0.30.0 (build: local, sha: unknown)
```
- After:
```none
score-implementation-sample 0.30.0 (go1.26.1 - linux/amd64)
git commit: 2b994a35d0593c66f908135d5c321b0fd4d5c553
build date: 2026-01-01T18:28:02Z
```

Note: we can see that the `-dirty` suffix of the `git commit`/`sha` is fixed and that we are also adding more insightful information like the runtime version and platform. The `build` and `git commit`/`sha` are also now fixed when running the container image.

New `score-implementation-sample version` command:
```none

                   ...    .............           
               .......   .............            
           .........     ............             
       .........        .....                     
      .......           ....   ..                 
       ..........      .....   ......             
           ........   ......   ..........         
              .....   .....       ..........      
                      ....          ........      
              ...........       .........         
           ..............    .........            
         ................   ......                
         ...............    ..                    
          ............

score-implementation-sample 0.30.0 (go1.26.1 - linux/amd64)
git commit: 2b994a35d0593c66f908135d5c321b0fd4d5c553
build date: 2026-01-01T18:28:02Z

A newer version is available: v0.3.0
Update at: https://github.com/score-spec/score-implementation-sample/releases/tag/v0.3.0
```

Note: we can see that this new command `version` generating the same output as `--version`, and add the Score logo (which can be disabled with `--no-logo`), and the versions update check (which can be disabled with `--no-updates-check`).